### PR TITLE
Update log4j to 2.17.1

### DIFF
--- a/log4j2/pom.xml
+++ b/log4j2/pom.xml
@@ -15,7 +15,7 @@
     <artifactId>kumuluzee-logs-log4j2</artifactId>
 
     <properties>
-        <log4j2.version>2.17.0</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
         <disruptor.version>3.4.2</disruptor.version>
     </properties>
 


### PR DESCRIPTION
Fix: https://nvd.nist.gov/vuln/detail/CVE-2021-44832